### PR TITLE
Also return wasIntersecting from useIsIntersecting

### DIFF
--- a/example/src/domain/App.js
+++ b/example/src/domain/App.js
@@ -4,9 +4,16 @@ import styles from './App.css'
 
 export default function App() {
   const [root, setRoot] = React.useState(null)
-  const [rootMargin, setRootMargin] = React.useState('-10%')
-  const { ref: isIntersectingRef, isIntersecting } = useIsIntersecting({ root, rootMargin })
-  const { ref: wasIntersectingRef, wasIntersecting } = useWasIntersecting({ root, rootMargin })
+  const [rootMargin, setRootMargin] = React.useState('-25%')
+  const {
+    ref: element1Ref,
+    isIntersecting: element1IsIntersecting,
+    wasIntersecting: element1WasIntersecting
+  } = useIsIntersecting({ root, rootMargin })
+  const {
+    ref: element2Ref,
+    wasIntersecting: element2WasIntersecting
+  } = useWasIntersecting({ root, rootMargin })
 
   const rootMarginStyles = visualizeRootMargin(rootMargin)
 
@@ -22,21 +29,23 @@ export default function App() {
         <div className={styles.rootMargin} style={rootMarginStyles} />
         <div ref={setRoot} className={styles.scroll}>
           <div
-            className={cx(styles.element, isIntersecting && styles.isRevealed)}
-            ref={isIntersectingRef}
+            className={cx(styles.element, element1IsIntersecting && styles.isRevealed)}
+            ref={element1Ref}
           >
-            {isIntersecting
-              ? "Is in intersection root element"
-              : "Is not in intersection root element"}
+            {element1IsIntersecting
+              ? 'Is in intersection root element'
+              : element1WasIntersecting
+              ? 'Is not in intersection root element anymore'
+              : 'Is not in intersection root element'}
           </div>
 
           <div
-            className={cx(styles.element, wasIntersecting && styles.isRevealed)}
-            ref={wasIntersectingRef}
+            className={cx(styles.element, element2WasIntersecting && styles.isRevealed)}
+            ref={element2Ref}
           >
-            {wasIntersecting
-              ? "Has been in intersection root element"
-              : "Has not yet been in intersection root element"}
+            {element2WasIntersecting
+              ? 'Has been in intersection root element'
+              : 'Has not yet been in intersection root element'}
           </div>
         </div>
       </div>

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,29 @@ export default function App() {
 }
 ```
 
+The `useIsIntersecting` hook also returns wether an element has been intersecting in the past (`wasIntersecting`). The main difference with the dedicated `useWasIntersecting` hook is that the IntersectionObserver doesn't get cleaned up, since the hook still has to track wether the element is currently intersecting. This can be useful if you want to pause an expensive operation, but also want the element to have a reveal animation.
+
+```jsx
+export default function App() {
+  const [root, setRoot] = React.useState(null)
+  const { ref: elementRef, isIntersecting, wasIntersecting } = useIsIntersecting({ root })
+
+  return (
+    <div>
+      <div className={styles.scrollWrapper}>
+        <div ref={setRoot} className={styles.scroll}>
+          <div ref={elementRef} className={cx(wasIntersecting && styles.isRevealed)}>
+            {isIntersecting 
+              ? 'Is in intersection root element'  
+              : 'Is not in intersection root element'}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
 ![](https://media.giphy.com/media/H9TLJHctw7Efm/giphy.gif)
 
 ## Disclaimer

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,14 @@ import { useObservedRef } from '@kaliber/use-observed-ref'
 
 export function useIsIntersecting({ root = null, rootMargin = undefined, threshold = undefined, disabled = undefined }) {
   const [isIntersecting, setIsIntersecting] = React.useState(false)
+  const [wasIntersecting, setWasIntersecting] = React.useState(false)
   const createObserver = React.useCallback(
     // @ts-ignore
     () => new window.IntersectionObserver(
-      ([entry]) => { setIsIntersecting(entry.isIntersecting) },
+      ([entry]) => { 
+        setIsIntersecting(entry.isIntersecting) 
+        setWasIntersecting(wasIntersecting => wasIntersecting || entry.isIntersecting) 
+      },
       { root, rootMargin, threshold }
     ),
     [root, rootMargin, threshold]
@@ -14,17 +18,17 @@ export function useIsIntersecting({ root = null, rootMargin = undefined, thresho
   const reset = React.useCallback(() => { setIsIntersecting(false) }, [])
   const ref = useObservedRef({ createObserver, reset, disabled })
 
-  return { ref, isIntersecting }
+  return { ref, isIntersecting, wasIntersecting }
 }
 
 export function useWasIntersecting({ root, rootMargin, threshold }) {
   const [disabled, setDisabled] = React.useState(false)
-  const { ref, isIntersecting } = useIsIntersecting({ root, rootMargin, threshold, disabled })
+  const { ref, wasIntersecting } = useIsIntersecting({ root, rootMargin, threshold, disabled })
 
   React.useEffect(
-    () => { isIntersecting && setDisabled(true) },
-    [isIntersecting]
+    () => { wasIntersecting && setDisabled(true) },
+    [wasIntersecting]
   )
 
-  return { wasIntersecting: isIntersecting, ref }
+  return { wasIntersecting, ref }
 }


### PR DESCRIPTION
Dit PR voegt de return value `wasIntersecting` toe aan de `useIsIntersecting` hook. In het Alliander project bleek dat useIsIntersecting en useWasIntersecting op 1 element werden gebruikt:
- Om de canvas animatie te pauzeren (isIntersecting)
- Om een reveal animatie in te zetten (wasIntersecting)

Het is niet handig om in dit geval 2 hooks te gebruiken. Zeker gezien useIsIntersecting eigenlijk bijna alle nodige informatie al bescshikbaar heeft.